### PR TITLE
Fixes resource bundle in Swift

### DIFF
--- a/Source/Categories/NSBundle+DBLibrary.m
+++ b/Source/Categories/NSBundle+DBLibrary.m
@@ -33,9 +33,10 @@ NSString * const kLocalizedStringNotFound = @"kLocalizedStringNotFound";
 + (instancetype)dbAttachmentPickerResourceBundle {
     NSBundle *bundle = [NSBundle mainBundle];
     NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"DBAttachmentPickerController" ofType:@"bundle"];
-    if (bundlePath) {
-        bundle = [NSBundle bundleWithPath:bundlePath];
+    if (!bundlePath) {
+        bundlePath = [[NSBundle bundleForClass:[DBAttachmentPickerController class]] pathForResource:@"DBAttachmentPickerController" ofType:@"bundle"];
     }
+    bundle = [NSBundle bundleWithPath:bundlePath];
     return bundle;
 }
 

--- a/Source/Categories/NSBundle+DBLibrary.m
+++ b/Source/Categories/NSBundle+DBLibrary.m
@@ -36,7 +36,9 @@ NSString * const kLocalizedStringNotFound = @"kLocalizedStringNotFound";
     if (!bundlePath) {
         bundlePath = [[NSBundle bundleForClass:[DBAttachmentPickerController class]] pathForResource:@"DBAttachmentPickerController" ofType:@"bundle"];
     }
-    bundle = [NSBundle bundleWithPath:bundlePath];
+    if (bundlePath) {
+        bundle = [NSBundle bundleWithPath:bundlePath];
+    }
     return bundle;
 }
 

--- a/Source/Cells/DBThumbnailPhotoCell.h
+++ b/Source/Cells/DBThumbnailPhotoCell.h
@@ -20,6 +20,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <Photos/PHImageManager.h>
 #import "DBAssetImageView.h"
 
 @interface DBThumbnailPhotoCell : UICollectionViewCell
@@ -29,6 +30,7 @@
 
 @property (assign, nonatomic) BOOL needsDisplayEmptySelectedIndicator;
 @property (copy, nonatomic, nullable) NSString *identifier;
+@property (nonatomic) PHImageRequestID phImageRequestID;
 
 @property (assign, nonatomic) CGFloat selectorOffset;
 

--- a/Source/DBAssetPickerController/DBAssetItemsViewController.m
+++ b/Source/DBAssetPickerController/DBAssetItemsViewController.m
@@ -185,6 +185,9 @@ static NSString * const reuseIdentifier = @"Cell";
     cell.tintColor = self.collectionView.tintColor;
     cell.identifier = asset.localIdentifier;
     cell.needsDisplayEmptySelectedIndicator = NO;
+    
+    [self.imageManager cancelImageRequest:cell.phImageRequestID];
+    
     [cell.assetImageView configureWithAssetMediaType:asset.mediaType subtype:asset.mediaSubtypes];
     
     if (asset.mediaType == PHAssetMediaTypeVideo) {
@@ -201,15 +204,20 @@ static NSString * const reuseIdentifier = @"Cell";
     CGSize size = [self collectionItemCellSizeAtIndexPath:indexPath];
     CGSize scaledThumbnailSize = CGSizeMake( size.width * scale, size.height * scale );
     
-    [self.imageManager requestImageForAsset:asset
+    PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+    options.resizeMode = PHImageRequestOptionsResizeModeExact;
+    options.deliveryMode = PHImageRequestOptionsDeliveryModeOpportunistic;
+    
+    cell.phImageRequestID = [self.imageManager requestImageForAsset:asset
                                  targetSize:scaledThumbnailSize
                                 contentMode:PHImageContentModeAspectFill
-                                    options:nil
+                                    options:options
                               resultHandler:^(UIImage *result, NSDictionary *info) {
                                   if ([cell.identifier isEqualToString:asset.localIdentifier]) {
                                       cell.assetImageView.image = result;
                                   }
                               }];
+    
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {

--- a/Source/Models/DBAttachment.m
+++ b/Source/Models/DBAttachment.m
@@ -77,7 +77,7 @@
     NSData *imgData = UIImageJPEGRepresentation(image, 1);
     model.fileSize = imgData.length;
     model.creationDate = [NSDate date];
-    model.fileName = @"capturedimage";
+    model.fileName = @"capturedimage.jpg";
     
     return model;
 }


### PR DESCRIPTION
Resource bundle will be properly loaded when using `DBAttachmentPickerController` as a framework in Swift.