### PR TITLE
fixed crash when the user selected a picture

### DIFF
--- a/Source/Models/DBAttachment.m
+++ b/Source/Models/DBAttachment.m
@@ -184,10 +184,12 @@
     switch (self.sourceType) {
         case DBAttachmentSourceTypePHAsset:
             if (completion) {
+                PHImageRequestOptions *options = [PHImageRequestOptions new];
+                options.synchronous = YES;
                 [[PHImageManager defaultManager] requestImageForAsset:self.photoAsset
                                                            targetSize:PHImageManagerMaximumSize
                                                           contentMode:PHImageContentModeDefault
-                                                              options:nil
+                                                              options:options
                                                         resultHandler:^(UIImage *result, NSDictionary *info) {
                                                             completion(result);
                                                         }];


### PR DESCRIPTION
(tested device iPad pro, ios 13.1.3, app - AIMSMobile / IHF_App)

app crashed because method imagePickerControllerFinishPickingBlock works with dispatch_groups, and call requestImageForAsset" method , which
caused resultHandler two times, if "synchronous" property - is false

[link to apple documentation](https://developer.apple.com/documentation/photokit/phimagemanager/1616964-requestimageforasset?language=objc)
> By default, this method executes asynchronously. If you call it from a background thread you may change the synchronous property of the options parameter to YES to block the calling thread until either the requested image is ready or an error occurs, at which time Photos calls your result handler.

> For an asynchronous request, Photos may call your result handler block more than once. Photos first calls the block to provide a low-quality image suitable for displaying temporarily while it prepares a high-quality image. (If low-quality image data is immediately available, the first call may occur before the method returns.) When the high-quality image is ready, Photos calls your result handler again to provide it. If the image manager has already cached the requested image at full quality, Photos calls your result handler only once. The PHImageResultIsDegradedKey key in the result handler’s info parameter indicates when Photos is providing a temporary low-quality image.

screen:
![Снимок экрана 2019-10-24 в 19 02 29](https://user-images.githubusercontent.com/26360868/67573762-22808780-f74a-11e9-874f-ac1b31e10c18.png)